### PR TITLE
BF: Fix ioHub finding eyetracker #3

### DIFF
--- a/psychopy_eyetracker_pupil_labs/pupil_labs/neon/default_eyetracker.yaml
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/neon/default_eyetracker.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.pupil_labs.neon.EyeTracker:
+eyetracker.pupil_labs.neon.EyeTracker:
     # Indicates if the device should actually be loaded at experiment runtime.
     enable: True
 

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/default_eyetracker.yaml
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/default_eyetracker.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.pupil_labs.pupil_core.EyeTracker:
+eyetracker.pupil_labs.pupil_core.EyeTracker:
     # Indicates if the device should actually be loaded at experiment runtime.
     enable: True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,9 @@ where = ["", "psychopy_eyetracker_pupil_labs",]
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.png"]
 
-[project.entry-points."psychopy.iohub.devices"]
-NeonEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.neon.eyetracker:NeonEyeTracker"
-PupilCoreEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core.eyetracker:PupilCoreEyeTracker"
-
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
-NeonEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.neon.eyetracker:NeonEyeTracker"
-PupilCoreEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core.eyetracker:PupilCoreEyeTracker"
+neon = "psychopy_eyetracker_pupil_labs.pupil_labs.neon"
+pupil_core = "psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core"
 
 [project.entry-points."psychopy.experiment.components"]
 AprilTagComponent = "psychopy_eyetracker_pupil_labs:AprilTagComponent"


### PR DESCRIPTION
In conjunction with [this PR](https://github.com/psychopy/psychopy/pull/6574) to PsychoPy, these changes allow ioHub to find the eyetracker class and its associated YAML via its entry point into PsychoPy.