### PR TITLE
Removes recording-enabled setting

### DIFF
--- a/psychopy_eyetracker_pupil_labs/pupil_labs/neon/default_eyetracker.yaml
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/neon/default_eyetracker.yaml
@@ -53,4 +53,3 @@ eyetracker.hw.pupil_labs.neon.EyeTracker:
     runtime_settings:
         companion_address: neon.local
         companion_port: 8080
-        recording_enabled: True

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/neon/eyetracker.py
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/neon/eyetracker.py
@@ -190,11 +190,10 @@ class NeonEyeTracker(EyeTrackerDevice):
         if not self.isConnected():
             return False
 
-        if self._runtime_settings["recording_enabled"]:
-            if should_be_recording:
-                self._device.recording_start()
-            else:
-                self._device.recording_stop_and_save()
+        if should_be_recording:
+            self._device.recording_start()
+        else:
+            self._device.recording_stop_and_save()
 
         self._actively_recording = should_be_recording
 

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/eyetracker.py
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/eyetracker.py
@@ -109,7 +109,6 @@ class PupilCoreEyeTracker(EyeTrackerDevice):
         self._pupil_remote_subscriptions.append("notify.calibration")
 
         capture_recording_settings = self._runtime_settings["pupil_capture_recording"]
-        self._capture_recording_enabled = capture_recording_settings["enabled"]
         self._capture_recording_location = capture_recording_settings["location"]
 
         self._gaze_bisectors_by_topic = defaultdict(MutableBisector)
@@ -256,16 +255,14 @@ class PupilCoreEyeTracker(EyeTrackerDevice):
         """
         if not self.isConnected():
             return False
-        if self._capture_recording_enabled:
-            if should_be_recording:
-                self._pupil_remote.start_recording(
-                    rec_name=self._capture_recording_location
-                )
-            else:
-                self._pupil_remote.stop_recording()
-            self._actively_recording = self._pupil_remote.is_recording
+
+        if should_be_recording:
+            self._pupil_remote.start_recording(
+                rec_name=self._capture_recording_location
+            )
         else:
-            self._actively_recording = should_be_recording
+            self._pupil_remote.stop_recording()
+        self._actively_recording = self._pupil_remote.is_recording
 
         is_recording_enabled = self.isRecordingEnabled()
 


### PR DESCRIPTION
Perhaps this setting existed before the eyetracker start/stop functions existed, but now it seems superfluous.

This is paired with a [PR on psychopy:dev](https://github.com/psychopy/psychopy/pull/6735)