### PR TITLE
RF: Reconfigure project to be detected by ioHub

### DIFF
--- a/psychopy_eyetracker_pupil_labs/pupil_labs/neon/__init__.py
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/neon/__init__.py
@@ -4,6 +4,6 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 from psychopy.iohub.devices.eyetracker.eye_events import BinocularEyeSampleEvent
-from .eyetracker import NeonEyeTracker
+from .eyetracker import EyeTracker
 
-__all__ = ["NeonEyeTracker", "BinocularEyeSampleEvent"]
+__all__ = ["EyeTracker", "BinocularEyeSampleEvent"]

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/neon/default_eyetracker.yaml
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/neon/default_eyetracker.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.pupil_labs.neon.EyeTracker:
+eyetracker.neon.EyeTracker:
     # Indicates if the device should actually be loaded at experiment runtime.
     enable: True
 

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/neon/eyetracker.py
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/neon/eyetracker.py
@@ -18,7 +18,7 @@ from pupil_labs.real_time_screen_gaze.gaze_mapper import GazeMapper
 logger = logging.getLogger(__name__)
 
 
-class NeonEyeTracker(EyeTrackerDevice):
+class EyeTracker(EyeTrackerDevice):
     """
     Implementation of the :py:class:`Common Eye Tracker Interface <.EyeTrackerDevice>`
     for the Pupil Core headset.

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/__init__.py
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/__init__.py
@@ -6,6 +6,6 @@ from psychopy.iohub.devices.eyetracker.eye_events import (
     MonocularEyeSampleEvent,
     BinocularEyeSampleEvent,
 )
-from .eyetracker import PupilCoreEyeTracker
+from .eyetracker import EyeTracker
 
-__all__ = ["PupilCoreEyeTracker", "MonocularEyeSampleEvent", "BinocularEyeSampleEvent"]
+__all__ = ["EyeTracker", "MonocularEyeSampleEvent", "BinocularEyeSampleEvent"]

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/default_eyetracker.yaml
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/default_eyetracker.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.pupil_labs.pupil_core.EyeTracker:
+eyetracker.pupil_core.EyeTracker:
     # Indicates if the device should actually be loaded at experiment runtime.
     enable: True
 

--- a/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/eyetracker.py
+++ b/psychopy_eyetracker_pupil_labs/pupil_labs/pupil_core/eyetracker.py
@@ -23,7 +23,7 @@ from psychopy.iohub.errors import print2err, printExceptionDetailsToStdErr
 logger = logging.getLogger(__name__)
 
 
-class PupilCoreEyeTracker(EyeTrackerDevice):
+class EyeTracker(EyeTrackerDevice):
     """
     Implementation of the :py:class:`Common Eye Tracker Interface <.EyeTrackerDevice>`
     for the Pupil Core headset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,9 @@ where = ["", "psychopy_eyetracker_pupil_labs",]
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.png"]
 
-[project.entry-points."psychopy.iohub.devices"]
-NeonEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.neon.eyetracker:NeonEyeTracker"
-PupilCoreEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core.eyetracker:PupilCoreEyeTracker"
-
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
-NeonEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.neon.eyetracker:NeonEyeTracker"
-PupilCoreEyeTracker = "psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core.eyetracker:PupilCoreEyeTracker"
+neon = "psychopy_eyetracker_pupil_labs.pupil_labs.neon"
+pupil_core = "psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core"
 
 [project.entry-points."psychopy.experiment.components"]
 AprilTagComponent = "psychopy_eyetracker_pupil_labs:AprilTagComponent"


### PR DESCRIPTION
Should achieve what #5 could not - as ioHub needs eyetracker classes to be named EyeTracker, the entry point needs to point an entire module to `psychopy.iohub.devices.eyetracker` and then the yaml needs to navigate from `psychopy.iohub.devices` to the necessary class.